### PR TITLE
Add authToken, language setters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "tzk/taiga-php",
     "description": "A PHP wrapper for the Taiga.io API",
     "license": "MIT",
+    "type": "package",
     "require": {
         "php": "~5.3|~7.0",
         "php-curl-class/php-curl-class": "^4.11"


### PR DESCRIPTION
 - now it is possible to do following
   - assume worker is doing job on background
   - this job involves multiple users (auth tokens needed, stored in db.)
 - **before**: you had to new up instance of Taiga (with new token) for each user
 - **now**: you can change auth token / language on the fly

```php
$taiga = new Taiga('api...', 'user one');
$taiga->projects()->get() //process data of user one
$taiga->setAuthToken('user two')->projects()->get() // process data of user two
```
or 
```php
$taiga = new Taiga('api...');
$taiga->setAuthToken('token for user one')->users()->getMe();
$taiga->setAuthToken('token for user two')->users()->getMe();
```